### PR TITLE
Add direct-relative assembly mnemonics with a numeric displacement.

### DIFF
--- a/bcomp-assembler/src/main/antlr4/ru.ifmo.cs.bcomp.grammar/BCompNG.g4
+++ b/bcomp-assembler/src/main/antlr4/ru.ifmo.cs.bcomp.grammar/BCompNG.g4
@@ -101,6 +101,7 @@ displacementSP
 
 directRelative
    : label
+   | '(' ip '+' number ')'
    ;
 
 directLoad

--- a/bcomp-assembler/src/main/java/ru/ifmo/cs/bcomp/assembler/AddressingMode.java
+++ b/bcomp-assembler/src/main/java/ru/ifmo/cs/bcomp/assembler/AddressingMode.java
@@ -41,6 +41,7 @@ public class AddressingMode {
                 s="&undef"; break;
             case DIRECT_RELATIVE:
                 if (reference != null ) {s = reference; break;}
+                if (number != MemoryWord.UNDEFINED ) {s = "(ip+" + number + ")"; break;}
                 s="undef"; break;
             case DIRECT_LOAD: 
                 if (number != MemoryWord.UNDEFINED ) {s = "#"+number; break;}

--- a/bcomp-assembler/src/test/java/ru/ifmo/cs/bcomp/assembler/AsmNgTest.java
+++ b/bcomp-assembler/src/test/java/ru/ifmo/cs/bcomp/assembler/AsmNgTest.java
@@ -1,0 +1,108 @@
+package ru.ifmo.cs.bcomp.assembler;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class AsmNgTest {
+    @Test
+    public void directAbsoluteAddressingMode() {
+        validateConversion("JUMP 0x5", "C005");
+        validateConversion("SAME: ADD $SAME", "4000");
+
+        assertHasErrors("LD -10");
+        assertHasErrors("LD 0x800");
+        assertHasErrors("LD $UNDEFINED");
+    }
+
+    @Test
+    public void indirectAddressingMode() {
+        validateConversion("SAME: ADD (SAME)", "48FF");
+
+        assertHasErrors("LD (10)");
+        assertHasErrors("LD $UNDEFINED");
+    }
+
+    @Test
+    public void postIncrementAddressingMode() {
+        validateConversion("SAME: ADD (SAME)+", "4AFF");
+
+        assertHasErrors("LD (10)+");
+        assertHasErrors("LD (UNDEFINED)+");
+    }
+
+    @Test
+    public void preDecrementAddressingMode() {
+        validateConversion("SAME: ADD -(SAME)", "4BFF");
+
+        assertHasErrors("LD -(10)");
+        assertHasErrors("LD -(UNDEFINED)");
+    }
+
+    @Test
+    public void displacementSPAddressingMode() {
+        validateConversion("LD (Sp+-0x5)", "ACFB");
+        validateConversion("LD &0xF", "AC0F");
+
+        assertHasErrors("LD (sp+128)");
+        assertHasErrors("LD &UNDEFINED");
+    }
+
+    @Test
+    public void directRelativeAddressingMode() {
+        validateConversion("JUMP (ip+5)", "CE05");
+        validateConversion("SAME: ADD SAME", "4EFF");
+        validateConversion("LD (ip+-2)", "AEFE");
+
+        assertHasErrors("LD (ip+-129)");
+        assertHasErrors("LD (ip+128)");
+        assertHasErrors("LD UNDEFINED");
+    }
+
+    @Test
+    public void directLoadAddressingMode() {
+        validateConversion("LD #0x10", "AF10");
+        validateConversion("LD #0xFF", "AFFF");
+
+        assertHasErrors("LD #256");
+        assertHasErrors("LD #-129");
+        assertHasErrors("LD #UNDEFINED");
+    }
+
+    private static void validateConversion(String assembly, String instruction) {
+        validateProgram(Collections.singletonMap(assembly, instruction));
+    }
+
+    private static void validateProgram(Map<String, String> assemblyToInstruction) {
+        AsmNg sourceCode = getAssemblySource(assemblyToInstruction.keySet());
+        Program program = sourceCode.compile();
+        assertNotNull(program);
+        assertEquals("Errors occurred while compiling [" + assemblyToInstruction.keySet() + "]", Collections.EMPTY_LIST, sourceCode.getErrors());
+        String[] correctInstructions = assemblyToInstruction.values().toArray(new String[]{});
+
+        for (int i = 0; i < program.binary.size(); i++) {
+            String actual = getHexInstruction(program.binary.get(i));
+            String expected = correctInstructions[i];
+            assertEquals(expected, actual);
+        }
+    }
+
+    private static void assertHasErrors(String assembly) {
+        AsmNg sourceCode = getAssemblySource(Collections.singleton(assembly));
+        sourceCode.compile();
+        assertNotEquals("No errors occurred while compiling [" + assembly + "]", Collections.EMPTY_LIST, sourceCode.getErrors());
+    }
+
+    private static AsmNg getAssemblySource(Collection<String> assembly) {
+        return new AsmNg(assembly.stream().collect(Collectors.joining("\n", "ORG 0\nSTART: \n", "")));
+    }
+
+    private static String getHexInstruction(int value) {
+        return Integer.toHexString(value).toUpperCase();
+    }
+}


### PR DESCRIPTION
### This feature request introduces a possibility to use a numeric displacement in a direct-relative addressing mode.
Previously, we could only use labels with direct-relative addressing mode in assembly, like `JUMP L_NAME`.  But it wasn't really convenient to add new labels just to implement simple two-lines loop or jump a few lines.

Alternative way of defining direct-relative mnemonics `JUMP (IP+5)` was shown in a bcomp manual, so I decided to implement it.
Now, this mode supports both label reference and numeric displacement mnemonics.

Also, I wrote tests that cover conversions of assembly to instructions for all addressing modes.