### PR TITLE
Auto-build executable jar when pull request is merged

### DIFF
--- a/.github/workflows/release_jar.yml
+++ b/.github/workflows/release_jar.yml
@@ -1,0 +1,25 @@
+name: "Build and upload artifacts"
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    if: github.event.pull_request.merged == true
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: '8'
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{github.ref_name}}
+        files: bcomp-ng-ui/target/bcomp-ng.jar


### PR DESCRIPTION
Uses Github CI to automatically build and publish executable jar to the _Release_ page after successful merge. 

This will work starting from the next pull request. 