### PR TITLE
fix(bcomp-axl): evaluate compound-assignment lvalue once

### DIFF
--- a/bcomp-axl/src/main/java/ru/ifmo/cs/bcomp/axl/Gen.java
+++ b/bcomp-axl/src/main/java/ru/ifmo/cs/bcomp/axl/Gen.java
@@ -786,6 +786,9 @@ public final class Gen {
     private Ast.Type genAssign(Ast.Assign a) {
         if (!a.op.equals("=")) {
             String bop = a.op.substring(0, a.op.length() - 1);
+            if (isIndirectLvalue(a.target)) {
+                return genCompoundIndirect(a, bop);
+            }
             Ast.Binary syn = new Ast.Binary();
             syn.line = a.line;
             syn.op = bop;
@@ -806,6 +809,92 @@ public final class Gen {
         genExpr(a.value);
         genStoreToLvalue(a.target);
         return typeOf(a.target);
+    }
+
+    private boolean isIndirectLvalue(Ast.Expr e) {
+        return e instanceof Ast.Index
+                || (e instanceof Ast.Unary && ((Ast.Unary) e).op.equals("*"));
+    }
+
+    private void genLvalueAddr(Ast.Expr target) {
+        if (target instanceof Ast.Index) {
+            genElemAddr((Ast.Index) target);
+        } else {
+            genExpr(((Ast.Unary) target).operand);
+        }
+    }
+
+    // address computed once, reused for read and write
+    private Ast.Type genCompoundIndirect(Ast.Assign a, String bop) {
+        usesPointer = true;
+        boolean unsigned = isUnsignedType(typeOf(a.target));
+        genLvalueAddr(a.target);
+        pushAc();
+        ins("ST p_" + curFunc);
+        ins("LD (p_" + curFunc + ")");
+        applyBinOp(bop, a.value, unsigned);
+        ins("ST $g__t");
+        popAc();
+        ins("ST p_" + curFunc);
+        ins("LD $g__t");
+        ins("ST (p_" + curFunc + ")");
+        return typeOf(a.target);
+    }
+
+    private void applyBinOp(String op, Ast.Expr right, boolean unsigned) {
+        if (op.equals("*") || op.equals("/") || op.equals("%")) {
+            pushAc();
+            genExpr(right);
+            pushAc();
+            String lbl;
+            if (op.equals("*")) { usesMul = true; lbl = "f___mul"; }
+            else if (op.equals("/")) { usesDiv = true; lbl = "f___div"; }
+            else { usesDiv = true; lbl = "f___mod"; }
+            ins("CALL $" + lbl);
+            ins("ST $g__t");
+            ins("POP"); tempDepth--;
+            ins("POP"); tempDepth--;
+            ins("LD $g__t");
+            return;
+        }
+        if (op.equals("<<") || op.equals(">>")) {
+            pushAc();
+            genExpr(right);
+            pushAc();
+            String lbl;
+            if (op.equals("<<")) { usesShl = true; lbl = "f___shl"; }
+            else if (unsigned) { usesShr = true; lbl = "f___shr"; }
+            else { usesSar = true; lbl = "f___sar"; }
+            ins("CALL $" + lbl);
+            ins("ST $g__t");
+            ins("POP"); tempDepth--;
+            ins("POP"); tempDepth--;
+            ins("LD $g__t");
+            return;
+        }
+        pushAc();
+        genExpr(right);
+        ins("ST $g__t");
+        popAc();
+        if (op.equals("+")) {
+            ins("ADD $g__t");
+        } else if (op.equals("-")) {
+            ins("SUB $g__t");
+        } else if (op.equals("&")) {
+            ins("AND $g__t");
+        } else if (op.equals("|")) {
+            ins("OR $g__t");
+        } else if (op.equals("^")) {
+            ins("ST $g__t2");
+            ins("AND $g__t");
+            ins("NOT");
+            ins("ST $g__t3");
+            ins("LD $g__t2");
+            ins("OR $g__t");
+            ins("AND $g__t3");
+        } else {
+            throw new CompileException(right.line, "unsupported compound operator " + op + "=");
+        }
     }
 
     private void genLongStore(String[] t, Ast.Expr v) {

--- a/bcomp-axl/src/test/java/ru/ifmo/cs/bcomp/axl/AxlCompoundLvalueTest.java
+++ b/bcomp-axl/src/test/java/ru/ifmo/cs/bcomp/axl/AxlCompoundLvalueTest.java
@@ -1,0 +1,45 @@
+package ru.ifmo.cs.bcomp.axl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+// Доказательство ОШИБКИ 1: составное присваивание (op=) в lvalue с побочным
+// эффектом должно вычислять адрес ровно один раз.
+// До фикса эти тесты падают, после фикса — проходят.
+// Положить в: bcomp-axl/src/test/java/ru/ifmo/cs/bcomp/axl/
+public class AxlCompoundLvalueTest {
+
+    @Test
+    public void pointerPostIncCompound() throws Exception {
+        AxlTestSupport.Result r = AxlTestSupport.run(
+                "int buf[3]; int r0; int r1; int rp;\n"
+                + "void main() {\n"
+                + "  int *p;\n"
+                + "  buf[0] = 10; buf[1] = 20; buf[2] = 30;\n"
+                + "  p = buf;\n"
+                + "  *p++ += 5;\n"
+                + "  r0 = buf[0]; r1 = buf[1]; rp = p - buf;\n"
+                + "  halt();\n"
+                + "}");
+        assertEquals(15, r.mem("g_r0")); // buf[0] += 5
+        assertEquals(20, r.mem("g_r1")); // buf[1] не тронут
+        assertEquals(1, r.mem("g_rp"));  // p сдвинулся ровно на один элемент
+    }
+
+    @Test
+    public void arrayIndexPostIncCompound() throws Exception {
+        AxlTestSupport.Result r = AxlTestSupport.run(
+                "int a[4]; int ri; int a0; int a1;\n"
+                + "void main() {\n"
+                + "  int i; i = 0;\n"
+                + "  a[0] = 0; a[1] = 0; a[2] = 0; a[3] = 0;\n"
+                + "  a[i++] += 10;\n"
+                + "  ri = i; a0 = a[0]; a1 = a[1];\n"
+                + "  halt();\n"
+                + "}");
+        assertEquals(1, r.mem("g_ri"));  // i увеличился ровно один раз
+        assertEquals(10, r.mem("g_a0")); // a[0] обновлён
+        assertEquals(0, r.mem("g_a1"));  // a[1] не тронут
+    }
+}


### PR DESCRIPTION
Составное присваивание (+=, -= и т.д.) вычисляет адрес левой части дважды.

Для a[i++] += x и *p++ += x это значит, что i++/p++ срабатывает два раза, и
чтение с записью идут в разные ячейки.

Пример:

    int buf[3];
    void main() {
        int *p;
        buf[0] = 10; buf[1] = 20; buf[2] = 30;
        p = buf;
        *p++ += 5;
        halt();
    }

Ожидается: buf[0] = 15, p -> buf[1].
Сейчас:    buf[0] = 10, buf[1] = 15 (перезаписан), p -> buf[2].

Причина: в genAssign составное присваивание раскрывается в t = t op v с
переиспользованием одного и того же узла target, поэтому адрес считается и при
чтении, и при записи.

Правка: для элемента массива и разыменования указателя адрес вычисляется один
раз и переиспользуется для чтения и записи. Для обычных переменных поведение не
меняется. Добавлен тест AxlCompoundLvalueTest, существующие тесты модуля проходят.
