### PR TITLE
docs(readme): make links clickable and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,18 @@
 This is simple computer model studied in ITMO University since 1982 by first year students. 
 Its features are simple instructions set (inspired from PDP-8 and PDP-11), simple microprogram model and logic scheme to easy learn basics of computer architecture.
 
-All documentation is unfortunativelly in Russian. You can look at https://se.ifmo.ru/courses/csbasics for details.
-There is also lectures track on https://www.youtube.com/playlist?list=PLBWafxh1dFuwbs2bc_ba_1FIm4SzFYg2p
+All documentation is unfortunately in Russian. See the [CS basics course page](https://se.ifmo.ru/courses/csbasics) for details.
+There is also a [lecture playlist on YouTube](https://www.youtube.com/playlist?list=PLBWafxh1dFuwbs2bc_ba_1FIm4SzFYg2p).
 
 There are two branches for old model v1 (this model was studied until year 2019) and next generation model v2 (current).
 Folder "docs" is for old model and would be deleted in the future for v3. 
 
 # Contributors
 Original version was created by
-- Serge V. Klimenkov github.com/serge-klimenkov
-- Dmitry Afanasiev github.com/MATPOCKuH
+- [Serge V. Klimenkov](https://github.com/serge-klimenkov)
+- [Dmitry Afanasiev](https://github.com/MATPOCKuH)
 
-Other contibutors can be founded on github.com/tune-it/bcomp page
+Other contributors can be found on the [tune-it/bcomp GitHub page](https://github.com/tune-it/bcomp).
 
 # License
 The project is distributed under MIT license. Feel free to use it in IT Architecture Education
-


### PR DESCRIPTION
## Summary

- Made README links clickable and easier to read.
- Fixed two typos in the documentation text.

## Changes

- Replaced raw URLs with Markdown links.
- Fixed `unfortunativelly` → `unfortunately`.
- Fixed `contibutors` → `contributors`.