### PR TITLE
fix(bcomp-axl): handle negative initializers, diagnose bad constants

### DIFF
--- a/bcomp-axl/src/main/java/ru/ifmo/cs/bcomp/axl/Gen.java
+++ b/bcomp-axl/src/main/java/ru/ifmo/cs/bcomp/axl/Gen.java
@@ -248,9 +248,13 @@ public final class Gen {
                 globals.put(g.name, s);
                 globalData.add(g);
             } else if (n instanceof Ast.OrgDirective) {
-                codeOrigin = ((Ast.OrgDirective) n).address & 0x7FF;
+                Ast.OrgDirective o = (Ast.OrgDirective) n;
+                checkAddress(o.line, o.address);
+                codeOrigin = o.address;
             } else if (n instanceof Ast.WordData) {
-                wordBlocks.add((Ast.WordData) n);
+                Ast.WordData w = (Ast.WordData) n;
+                checkAddress(w.line, w.address);
+                wordBlocks.add(w);
             } else if (n instanceof Ast.FuncDecl) {
                 Ast.FuncDecl f = (Ast.FuncDecl) n;
                 if (funcs.containsKey(f.name)) {
@@ -280,6 +284,13 @@ public final class Gen {
         }
         if (!funcs.containsKey("main")) {
             throw new CompileException(0, "function main is required");
+        }
+    }
+
+    private void checkAddress(int line, int addr) {
+        if (addr < 0 || addr > 0x7FF) {
+            throw new CompileException(line,
+                    "address 0x" + Integer.toHexString(addr) + " is out of range [0..0x7FF]");
         }
     }
 
@@ -755,6 +766,9 @@ public final class Gen {
         boolean unsigned = isUnsignedType(lt);
         if (b.right instanceof Ast.IntLit) {
             int k = ((Ast.IntLit) b.right).value;
+            if (k > 16) {
+                throw new CompileException(b.line, "shift count " + k + " is out of range [0..16]");
+            }
             genExpr(b.left);
             for (int i = 0; i < k; i++) {
                 if (b.op.equals("<<")) {
@@ -1485,7 +1499,7 @@ public final class Gen {
                 }
                 vals.append(wordArgText(w.items.get(i)));
             }
-            line("        ORG 0x" + Integer.toHexString(w.address & 0x7FF));
+            line("        ORG 0x" + Integer.toHexString(w.address));
             line("        WORD " + vals);
         }
     }
@@ -1522,6 +1536,9 @@ public final class Gen {
         }
         if (g.arraySize >= 0) {
             if (g.init != null && !g.init.isEmpty()) {
+                if (g.init.size() > g.arraySize) {
+                    throw new CompileException(g.line, "too many initializers for array " + g.name);
+                }
                 StringBuilder vals = new StringBuilder();
                 for (int i = 0; i < g.init.size(); i++) {
                     if (i > 0) {
@@ -1546,8 +1563,8 @@ public final class Gen {
     }
 
     private String constText(Ast.Expr e) {
-        if (e instanceof Ast.IntLit) {
-            return String.format("0x%04X", ((Ast.IntLit) e).value & 0xFFFF);
+        if (isIntConst(e)) {
+            return String.format("0x%04X", intConst(e) & 0xFFFF);
         }
         if (e instanceof Ast.Unary && ((Ast.Unary) e).op.equals("&")
                 && ((Ast.Unary) e).operand instanceof Ast.Ident) {
@@ -1815,6 +1832,14 @@ public final class Gen {
             }
         }
         throw new CompileException(e.line, "expected a global variable");
+    }
+
+    static boolean isIntConst(Ast.Expr e) {
+        if (e instanceof Ast.IntLit) {
+            return true;
+        }
+        return e instanceof Ast.Unary && ((Ast.Unary) e).op.equals("-")
+                && ((Ast.Unary) e).operand instanceof Ast.IntLit;
     }
 
     int intConst(Ast.Expr e) {

--- a/bcomp-axl/src/test/java/ru/ifmo/cs/bcomp/axl/AxlDeclDiagnosticsTest.java
+++ b/bcomp-axl/src/test/java/ru/ifmo/cs/bcomp/axl/AxlDeclDiagnosticsTest.java
@@ -1,0 +1,51 @@
+package ru.ifmo.cs.bcomp.axl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class AxlDeclDiagnosticsTest {
+
+    private String firstError(String src) {
+        AxlCompiler cc = new AxlCompiler();
+        String asm = cc.compile(src);
+        assertNull("expected a compile error for:\n" + src, asm);
+        assertTrue(!cc.getErrors().isEmpty());
+        return cc.getErrors().get(0);
+    }
+
+    @Test
+    public void negativeGlobalInitializer() throws Exception {
+        AxlTestSupport.Result r = AxlTestSupport.run(
+                "int x = -5; int y;\n"
+                + "void main() { y = x + 1; halt(); }");
+        assertEquals(0xFFFB, r.mem("g_x"));
+        assertEquals(0xFFFC, r.mem("g_y"));
+    }
+
+    @Test
+    public void tooManyArrayInitializers() {
+        String err = firstError("int a[2] = {1, 2, 3};\nvoid main() { halt(); }");
+        assertTrue(err, err.contains("too many initializers"));
+    }
+
+    @Test
+    public void orgOutOfRange() {
+        String err = firstError("org 0x8000;\nvoid main() { halt(); }");
+        assertTrue(err, err.contains("out of range"));
+    }
+
+    @Test
+    public void wordAddressOutOfRange() {
+        String err = firstError("void main() { halt(); }\nword 0x1000 : 1;");
+        assertTrue(err, err.contains("out of range"));
+    }
+
+    @Test
+    public void shiftCountOutOfRange() {
+        String err = firstError("int x;\nvoid main() { x = 1 << 40; halt(); }");
+        assertTrue(err, err.contains("shift count"));
+    }
+}


### PR DESCRIPTION
В объявлениях четыре проблемы. Одна не даёт скомпилировать нормальный код, а
остальные портят программу без ошибки.

1. Отрицательное значение у глобальной переменной

    int x = -5;
    void main() { halt(); }

    line 1: global initializer must be a constant

Минус в исходнике превращается в узел Ast.Unary, а constText умеет работать
только с Ast.IntLit, поэтому ругается на запись.

2. Значений в фигурных скобках больше, чем размер массива

    int a[2] = {1, 2, 3};

Компилируется молча. Размер, который написали, просто игнорируется, в памяти
оказывается три слова вместо двух.

3. Слишком большой адрес в org и word

    org 0x8000;

Адрес обрезается через & 0x7FF и превращается в org 0x0. Программа ложится
поверх вектора прерываний, при этом никакого сообщения нет. У word то же самое,
word 0x1000 уезжает на адрес 0x0.

4. Слишком большой сдвиг

    x = 1 << 40;

Разворачивается в 40 команд ASL. Если написать 1 << 0xFFFF, компилятор
сгенерирует 65535 команд.

Что сделано:

1. constText принимает -N, для этого используется уже готовый intConst.
2. Если значений в скобках больше размера массива, это ошибка.
3. Адрес в org и word проверяется на диапазон [0..0x7FF], а не обрезается.
4. Сдвиг больше чем на 16 это ошибка.

Добавлен AxlDeclDiagnosticsTest на все четыре случая. Тесты модуля проходят, 62
штуки.
